### PR TITLE
Fix dropdown menu background color

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,10 +19,10 @@ function App() {
           onChange={handleTypeChange}
           className="w-2/6 py-2 pl-3 text-white bg-transparent border border-gray-700 rounded appearance-none sm:w-24"
         >
-          <option value="">全部</option>
-          <option value="trap">陷阱卡</option>
-          <option value="magic">魔法卡</option>
-          <option value="monster">怪獸卡</option>
+          <option value="" className="bg-gray-900">全部</option>
+          <option value="trap" className="bg-gray-900">陷阱卡</option>
+          <option value="magic" className="bg-gray-900">魔法卡</option>
+          <option value="monster" className="bg-gray-900">怪獸卡</option>
         </select>
         <input
           type="text"


### PR DESCRIPTION
**Issue: Can't see the option's text unless you hover it.**
![image](https://user-images.githubusercontent.com/30827929/136954186-23da56c6-43d8-4e5c-ba53-f5e3de55260f.png)


**Solution: Make the background color of the options the same as the header.**
![image](https://user-images.githubusercontent.com/30827929/136954208-a7e95535-9c96-4d5a-ba10-1dfc5772066a.png)
